### PR TITLE
chore: use Playwright test runner package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "@testing-library/react": "^14.1.2",
     "@testing-library/jest-dom": "^6.2.0",
     "jsdom": "^23.0.1",
-    "playwright": "^1.39.0"
+    "@playwright/test": "^1.39.0"
   }
 }


### PR DESCRIPTION
## Summary
- use `@playwright/test` as the dev dependency for running e2e tests

## Testing
- `npm run test:e2e` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d0413804832399b03de12f0f2d24